### PR TITLE
Include optional header file

### DIFF
--- a/src/lib/psystems/psystems.h
+++ b/src/lib/psystems/psystems.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <queue>
 #include <memory>
+#include <optional>
 
 #include "include/options.h"
 #include "include/spec.h"


### PR DESCRIPTION
This is to fix the compilation error
```
[ 73%] Building CXX object CMakeFiles/llvmbmc.dir/lib/bmc/bmc.cpp.o
In file included from /home/parallels/research/arm/llvm_bmc/src/lib/bmc/bmc.cpp:13:
/home/parallels/research/arm/llvm_bmc/src/lib/psystems/psystems.h:104:10: error: ‘optional’ in namespace ‘std’ does not name a template type
  104 |     std::optional<Quantifier> get_quant(const llvm::Loop *);
      |          ^~~~~~~~
In file included from /home/parallels/research/arm/llvm_bmc/src/lib/bmc/bmc.cpp:13:
/home/parallels/research/arm/llvm_bmc/src/lib/psystems/psystems.h:1:1: note: ‘std::optional’ is defined in header ‘<optional>’; did you forget to ‘#include <optional>’?
  +++ |+#include <optional>
```